### PR TITLE
Patch left edge placement

### DIFF
--- a/src/lib/lib/config/map_config.py
+++ b/src/lib/lib/config/map_config.py
@@ -61,5 +61,5 @@ TILE_EXTERNAL_POS: dict[str, Callable[[int, int], tuple[int, int]]] = {
     "top_edge": lambda x, y: (x, y - 1),
     "right_edge": lambda x, y: (x + 1, y),
     "bottom_edge": lambda x, y: (x, y + 1),
-    "left_edge": lambda x, y: (x - 1, y - 1),
+    "left_edge": lambda x, y: (x - 1, y),
 }


### PR DESCRIPTION
TLDR: fix incorrect left edge coordinates

The left edge position in `TILE_EXTERNAL_POS` was incorrectly using `(x - 1, y - 1)`. This caused the river end tile to be placed in the wrong row when the open edge faced left. The dictionary now returns `(x - 1, y)` for the left edge.

No tests were present, but `ruff` formatting and checks succeeded.

------
https://chatgpt.com/codex/tasks/task_e_68748a0f103c832ebf1ed72b73d227f9