### PR TITLE
Fix persistent river-end tile state

### DIFF
--- a/src/lib/lib/interact/tile.py
+++ b/src/lib/lib/interact/tile.py
@@ -142,29 +142,25 @@ class Tile:
 
     @staticmethod
     def get_starting_tile() -> "Tile":
-        if not Tile.starting_tile:
-            Tile.starting_tile = Tile(
-                tile_id="RS",
-                left_edge=StructureType.GRASS,
-                right_edge=StructureType.GRASS,
-                top_edge=StructureType.RIVER,
-                bottom_edge=StructureType.GRASS,
-                modifiers=[TileModifier.RIVER],
-            )
-        return Tile.starting_tile
+        return Tile(
+            tile_id="RS",
+            left_edge=StructureType.GRASS,
+            right_edge=StructureType.GRASS,
+            top_edge=StructureType.RIVER,
+            bottom_edge=StructureType.GRASS,
+            modifiers=[TileModifier.RIVER],
+        )
 
     @staticmethod
     def get_river_end_tile() -> "Tile":
-        if not Tile.river_end_tile:
-            Tile.river_end_tile = Tile(
-                tile_id="RE",
-                left_edge=StructureType.GRASS,
-                right_edge=StructureType.GRASS,
-                top_edge=StructureType.GRASS,
-                bottom_edge=StructureType.RIVER,
-                modifiers=[TileModifier.RIVER],
-            )
-        return Tile.river_end_tile
+        return Tile(
+            tile_id="RE",
+            left_edge=StructureType.GRASS,
+            right_edge=StructureType.GRASS,
+            top_edge=StructureType.GRASS,
+            bottom_edge=StructureType.RIVER,
+            modifiers=[TileModifier.RIVER],
+        )
 
     def __init__(
         self,

--- a/tests/regression_river_end_tile_test.py
+++ b/tests/regression_river_end_tile_test.py
@@ -1,0 +1,16 @@
+from lib.interact.map import Map
+from lib.interact.tile import Tile
+
+
+def test_river_end_tile_fresh_instance_between_maps():
+    m1 = Map()
+    m1.start_river_phase()
+    m1.place_river_end((5, 5), rotation=1)
+
+    # Simulate starting a second map/game
+    m2 = Map()
+    m2.start_river_phase()
+
+    tile = Tile.get_river_end_tile()
+    assert tile.rotation == 0
+    assert tile.placed_pos is None


### PR DESCRIPTION
## Summary
- return a new starting tile and river-end tile on every call
- add regression test ensuring river-end tiles are fresh between games

## Testing
- `pre-commit run --files src/lib/lib/interact/tile.py tests/regression_river_end_tile_test.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883fd8df71c832e8bc15e268298b386